### PR TITLE
homework 8

### DIFF
--- a/kubernetes-monitoring/README
+++ b/kubernetes-monitoring/README
@@ -1,0 +1,20 @@
+Выполнено ДЗ № 8
+[+] Основное ДЗ
+
+В процессе сделано:
+- Создан кастомный образ nginx, отдающий свои метрики на эндпойнте /stub_status
+- В кластере установлен prometheus-operator с помощью helm (helm upgrade --install kube-prometheus oci://registry-1.docker.io/bitnamicharts/kube-prometheus -n monitoring --create-namespace)
+- Созданы манифесты для Deployment и Service для кастомного образа nginx
+- В манифест Deployment добавлен второй контейнер с nginx prometheus exporter
+- Создан манифест ServiceMonitor, описывающий сбор метрик от контейнера с nginx prometheus exporter
+
+Как запустить проект:
+- В директории kubernetes-monitoring запускаем команду "kubectl apply -f ."
+
+Как проверить работоспособность:
+- Убедиться, что созданы нужные сущности (kubectl -n homework get all -l app=nginx-stub-status)
+- Пробросить порт сервиса Prometheus на локальную машину (kubectl -n monitoring port-forward svc/kube-prometheus-prometheus 9090:9090)
+- Зайти в браузере по адресу http://localhost:9090 и убедиться, что метрики nginx prometheus exporter хранятся в Prometheus. Несколько таких метрик для примера: nginx_connections_accepted, nginx_connections_active, nginx_connections_handled, nginx_connections_reading.
+
+PR checklist:
+[+] Выставлен label с темой домашнего задания

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-stub-status
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-stub-status
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      name: nginx-stub-status
+      labels:
+        app: nginx-stub-status
+    spec:
+      containers: 
+      - name: nginx-stub-status 
+        image: vmasyagin/nginx-stub-status:0.0.1
+        readinessProbe:
+          httpGet:
+            path: /stub_status
+            port: 8080
+      - name: nginx-prometheus-exporter
+        args:
+          - "--nginx.scrape-uri=http://localhost:8080/stub_status"
+        image: nginx/nginx-prometheus-exporter:latest
+        ports:
+          - name: metrics
+            containerPort: 9113
+      nodeSelector:
+        homework: "true"

--- a/kubernetes-monitoring/docker/Dockerfile
+++ b/kubernetes-monitoring/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.25
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY default.conf /etc/nginx/conf.d/default.conf
+RUN groupadd -r -g 1001 app && useradd -r -u 1001 -g app app && \
+	touch /var/run/nginx.pid && \
+    chown -R app:app /var/run/nginx.pid && \
+    chown -R app:app /var/cache/nginx
+EXPOSE 8080
+USER app
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-monitoring/docker/default.conf
+++ b/kubernetes-monitoring/docker/default.conf
@@ -1,0 +1,13 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    location = /stub_status {
+        stub_status;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/kubernetes-monitoring/docker/nginx.conf
+++ b/kubernetes-monitoring/docker/nginx.conf
@@ -1,0 +1,33 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+
+include /etc/nginx/conf.d/*.stream;

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-stub-status
+  labels:
+    app: nginx-stub-status
+spec:
+  selector:
+    app: nginx-stub-status
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+      name: http
+    - port: 9113
+      targetPort: 9113
+      name: metrics

--- a/kubernetes-monitoring/servicemonitor.yaml
+++ b/kubernetes-monitoring/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-stub-status
+  labels:
+    team: homework
+spec:
+  selector:
+    matchLabels:
+      app: nginx-stub-status
+  endpoints:
+  - path: /metrics
+    port: metrics
+  jobLabel: nginx-stub-status


### PR DESCRIPTION
# Выполнено ДЗ № 8

 - [+] Основное ДЗ

## В процессе сделано:
 - Создан кастомный образ nginx, отдающий свои метрики на эндпойнте /stub_status
 - В кластере установлен prometheus-operator с помощью helm (helm upgrade --install kube-prometheus oci://registry-1.docker.io/bitnamicharts/kube-prometheus -n monitoring --create-namespace)
 - Созданы манифесты для Deployment и Service для кастомного образа nginx
 - В манифест Deployment добавлен второй контейнер с nginx prometheus exporter
 - Создан манифест ServiceMonitor, описывающий сбор метрик от контейнера с nginx prometheus exporter

## Как запустить проект:
 - В директории kubernetes-monitoring запускаем команду "kubectl apply -f ."

## Как проверить работоспособность:
 - Убедиться, что созданы нужные сущности (kubectl -n homework get all -l app=nginx-stub-status)
 - Пробросить порт сервиса Prometheus на локальную машину (kubectl -n monitoring port-forward svc/kube-prometheus-prometheus 9090:9090)
 - Зайти в браузере по адресу http://localhost:9090 и убедиться, что метрики nginx prometheus exporter хранятся в Prometheus. Несколько таких метрик для примера: nginx_connections_accepted, nginx_connections_active, nginx_connections_handled, nginx_connections_reading.

## PR checklist:
 - [+] Выставлен label с темой домашнего задания
