### PR TITLE
homework 11

### DIFF
--- a/kubernetes-vault/README
+++ b/kubernetes-vault/README
@@ -1,0 +1,73 @@
+Выполнено ДЗ № 11
+[+] Основное ДЗ
+
+В процессе сделано:
+- В неймспейсе consul был развернут consul из helm-чарта с 3 репликами для сервера
+- В неймспейсе vault был развернут vault из helm-чарта для использования consul в режиме HA
+- Выполнена инициализация vault и распечатаны все поды хранилища
+- Создано хранилище секретов otus с Secret Engine KV, в нем создан секрет otus/cred с содержанием из методического указания
+- В неймспейсе vault создан сервисный аккаунт vault-auth и ClusterRoleBinding для него с ролью system:auth-delegator
+- В Vault включена авторизация auth/kubernetes и сконфигурирована на использование токена и сертификата ранее созданного аккаунта
+- В Vault создана и применена политика otus-policy для секрета otus/cred
+- В Vault создана роль auth/kubernetes/role/otus, связывающая ServiceAccount vault-auth из неймспейса vault с политикой otus-policy
+- Установлен External Secrets Operator из helm-чарта в неймспейс vault
+- Создан и применен манифест кастомного ресурса SecretStore, сконфигурированный для доступа к KV секретам Vault и сервисный аккаунт vault-auth
+- Создан и применен манифест кастомного ресурса ExternalSecret по описанию из методического указания
+
+Как запустить проект:
+- Перейти в директорию kubernetes-vault, склонировать репозиторий с helm-чартом consul и установить chart: 
+    git clone git@github.com:hashicorp/consul-k8s.git
+    helm upgrade --install consul consul-k8s/charts/consul/ --set global.name=consul --create-namespace -n consul -f values-consul.yaml
+- В директории kubernetes-vault склонировать репозиторий с helm-чартом vault и установить chart:
+    git clone git@github.com:hashicorp/vault-helm.git
+    helm install vault vault-helm/ --create-namespace -n vault -f values-vault.yaml
+- Выполнить инициализацию Vault:
+    kubectl -n vault exec -it vault-0 -- vault operator init
+- Распечатать все поды хранилища:
+    kubectl -n vault exec -it vault-{0,1,2} -- vault operator unseal <UNSEAL_KEY_{1,2,3}>
+- Авторизоваться в Vault полученным при инициализации токеном:
+    kubectl -n vault exec -it vault-0 -- vault login <INITIAL_ROOT_TOKEN>
+- Создать хранилище секретов otus с Secret Engine KV:
+    kubectl -n vault exec -it vault-0 -- vault secrets enable -version=2 -path=otus kv
+- Создать секрет otus/cred и положить в него данные из методического указания:
+    kubectl -n vault exec -it vault-0 -- vault kv put otus/cred username='otus' password='asajkjkahs'
+- В директории последовательно выполнить команды:
+    kubectl apply -f sa.yaml
+    kubectl apply -f crb.yaml
+- В Vault включить авторизацию auth/kubernetes:
+    kubectl -n vault exec -it vault-0 -- vault auth enable kubernetes
+- Сконфигурировать авторизацию kubernetes на использование токена и сертификата ранее созданного аккаунта:
+    TOKEN_REVIEW_JWT=$(kubectl -n vault get secret vault-auth-token -o go-template='{{ .data.token }}' | base64 --decode)
+    KUBE_CA_CERT=$(kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 --decode)
+    KUBE_HOST=$(kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.server}')
+    kubectl -n vault exec -it vault-0 -- vault write auth/kubernetes/config \
+    token_reviewer_jwt="$TOKEN_REVIEW_JWT" \
+    kubernetes_host="$KUBE_HOST" \
+    kubernetes_ca_cert="$KUBE_CA_CERT" \
+    disable_local_ca_jwt="true"
+- Находясь в директории kubernetes-vault Создать и применить в Vault политику otus-policy для секрета otus/cred
+    cat otus-policy.hcl | kubectl -n vault exec -it vault-0 -- vault policy write otus-policy -
+- В Vault создать роль auth/kubernetes/role/otus:
+      kubectl -n vault exec -it vault-0 -- vault write auth/kubernetes/role/otus \
+        bound_service_account_names=vault-auth \
+        bound_service_account_namespaces=vault \
+        policies=otus-policy \
+        ttl=24h
+- Добавить репозиторий external-secrets с helm-чартами external-secrets и установить chart:
+    helm repo add external-secrets https://charts.external-secrets.io
+    helm upgrade --install external-secrets external-secrets/external-secrets --create-namespace -n vault
+- В директории kubernetes-vault выполнить команду:
+    kubectl apply -f secretstore.yaml
+- В директории kubernetes-vault выполнить команду:
+    kubectl apply -f externalsecret.yaml
+
+Как проверить работоспособность:
+- Проверить, что запустились все поды в неймспейсе consul:
+    kubectl -n consul get po
+- Проверить, что запустились все поды в неймспейсе vault:
+    kubectl -n vault get po
+- Проверить, что в неймспейсе vault появился секрет otus-cred, хранящий ключи username и password со значениями, взятыми из секрета otus/cred в Vault
+    kubectl -n vault get secret otus-cred -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
+
+PR checklist:
+[+] Выставлен label с темой домашнего задания

--- a/kubernetes-vault/crb.yaml
+++ b/kubernetes-vault/crb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-auth-binding
+  namespace: vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: vault

--- a/kubernetes-vault/externalsecret.yaml
+++ b/kubernetes-vault/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: otus-external-secret
+  namespace: vault
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: otus-secret-store
+    kind: SecretStore
+  target:
+    name: otus-cred
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: cred

--- a/kubernetes-vault/otus-policy.hcl
+++ b/kubernetes-vault/otus-policy.hcl
@@ -1,0 +1,3 @@
+path "otus/data/cred" {
+  capabilities = ["read", "list"]
+}

--- a/kubernetes-vault/sa.yaml
+++ b/kubernetes-vault/sa.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: vault
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: vault-auth
+  name: vault-auth-token
+  namespace: vault
+type: kubernetes.io/service-account-token

--- a/kubernetes-vault/secretstore.yaml
+++ b/kubernetes-vault/secretstore.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: otus-secret-store
+  namespace: vault
+spec:
+  retrySettings:
+    maxRetries: 5
+    retryInterval: "10s"
+
+  provider:
+    vault:
+      server: "http://vault.vault:8200"t
+      path: "otus"
+      version: "v2"
+      namespace: "vault"
+
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "otus"
+          serviceAccountRef:
+            name: "vault-auth"

--- a/kubernetes-vault/values-consul.yaml
+++ b/kubernetes-vault/values-consul.yaml
@@ -1,0 +1,24 @@
+# Server, when enabled, configures a server cluster to run. This should
+# be disabled if you plan on connecting to a Consul cluster external to
+# the Kube cluster.
+server:
+  # If true, the chart will install all the resources necessary for a
+  # Consul server cluster. If you're running Consul externally and want agents
+  # within Kubernetes to join that cluster, this should probably be false.
+  # @default: global.enabled
+  # @type: boolean
+  enabled: "-"
+
+  # Override global log verbosity level. One of "trace", "debug", "info", "warn", or "error".
+  # @type: string
+  logLevel: ""
+
+  # The name of the Docker image (including any tag) for the containers running
+  # Consul server agents.
+  # @type: string
+  image: null
+
+  # The number of server agents to run. This determines the fault tolerance of
+  # the cluster. Please refer to the [deployment table](https://developer.hashicorp.com/consul/docs/architecture/consensus#deployment-table)
+  # for more information.
+  replicas: 3

--- a/kubernetes-vault/values-vault.yaml
+++ b/kubernetes-vault/values-vault.yaml
@@ -1,0 +1,45 @@
+server:
+  ha:
+    enabled: true
+    replicas: 3
+
+    # config is a raw string of default configuration when using a Stateful
+    # deployment. Default is to use a Consul for its HA storage backend.
+    # This should be HCL.
+
+    # Note: Configuration files are stored in ConfigMaps so sensitive data
+    # such as passwords should be either mounted through extraSecretEnvironmentVars
+    # or through a Kube secret.  For more information see:
+    # https://developer.hashicorp.com/vault/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "consul" {
+        path = "vault"
+        address = "consul-server.consul:8500"
+      }
+
+      service_registration "kubernetes" {}
+
+      # Example configuration for using auto-unseal, using Google Cloud KMS. The
+      # GKMS keys must already exist, and the cluster must have a service account
+      # that is authorized to access GCP KMS.
+      #seal "gcpckms" {
+      #   project     = "vault-helm-dev-246514"
+      #   region      = "global"
+      #   key_ring    = "vault-helm-unseal-kr"
+      #   crypto_key  = "vault-helm-unseal-key"
+      #}
+
+      # Example configuration for enabling Prometheus metrics.
+      # If you are using Prometheus Operator you can enable a ServiceMonitor resource below.
+      # You may wish to enable unauthenticated metrics in the listener block above.
+      #telemetry {
+      #  prometheus_retention_time = "30s"
+      #  disable_hostname = true
+      #}


### PR DESCRIPTION
# Выполнено ДЗ № 11

 - [+] Основное ДЗ

## В процессе сделано:
 - В неймспейсе consul был развернут consul из helm-чарта с 3 репликами для сервера
 - В неймспейсе vault был развернут vault из helm-чарта для использования consul в режиме HA
 - Выполнена инициализация vault и распечатаны все поды хранилища
 - Создано хранилище секретов otus с Secret Engine KV, в нем создан секрет otus/cred с содержанием из методического указания
 - В неймспейсе vault создан сервисный аккаунт vault-auth и ClusterRoleBinding для него с ролью system:auth-delegator
 - В Vault включена авторизация auth/kubernetes и сконфигурирована на использование токена и сертификата ранее созданного аккаунта
 - В Vault создана и применена политика otus-policy для секрета otus/cred
 - В Vault создана роль auth/kubernetes/role/otus, связывающая ServiceAccount vault-auth из неймспейса vault с политикой otus-policy
 - Установлен External Secrets Operator из helm-чарта в неймспейс vault
 - Создан и применен манифест кастомного ресурса SecretStore, сконфигурированный для доступа к KV секретам Vault и сервисный аккаунт vault-auth
 - Создан и применен манифест кастомного ресурса ExternalSecret по описанию из методического указания

## Как запустить проект:
 - Перейти в директорию kubernetes-vault, склонировать репозиторий с helm-чартом consul и установить chart: 
    **git clone git@github.com:hashicorp/consul-k8s.git
    helm upgrade --install consul consul-k8s/charts/consul/ --set global.name=consul --create-namespace -n consul -f values-consul.yaml**
 - В директории kubernetes-vault склонировать репозиторий с helm-чартом vault и установить chart:
    **git clone git@github.com:hashicorp/vault-helm.git
    helm install vault vault-helm/ --create-namespace -n vault -f values-vault.yaml**
 - Выполнить инициализацию Vault:
    **kubectl -n vault exec -it vault-0 -- vault operator init**
 - Распечатать все поды хранилища:
    **kubectl -n vault exec -it vault-{0,1,2} -- vault operator unseal <UNSEAL_KEY_{1,2,3}>**
 - Авторизоваться в Vault полученным при инициализации токеном:
    **kubectl -n vault exec -it vault-0 -- vault login <INITIAL_ROOT_TOKEN>**
 - Создать хранилище секретов otus с Secret Engine KV:
    **kubectl -n vault exec -it vault-0 -- vault secrets enable -version=2 -path=otus kv**
 - Создать секрет otus/cred и положить в него данные из методического указания:
    **kubectl -n vault exec -it vault-0 -- vault kv put otus/cred username='otus' password='asajkjkahs'**
 - В директории последовательно выполнить команды:
    **kubectl apply -f sa.yaml
    kubectl apply -f crb.yaml**
 - В Vault включить авторизацию auth/kubernetes:
    **kubectl -n vault exec -it vault-0 -- vault auth enable kubernetes**
 - Сконфигурировать авторизацию kubernetes на использование токена и сертификата ранее созданного аккаунта:
    **TOKEN_REVIEW_JWT=$(kubectl -n vault get secret vault-auth-token -o go-template='{{ .data.token }}' | base64 --decode)
    KUBE_CA_CERT=$(kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 --decode)
    KUBE_HOST=$(kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.server}')
    kubectl -n vault exec -it vault-0 -- vault write auth/kubernetes/config \\
    token_reviewer_jwt="$TOKEN_REVIEW_JWT" \\
    kubernetes_host="$KUBE_HOST" \\
    kubernetes_ca_cert="$KUBE_CA_CERT" \\
    disable_local_ca_jwt="true"**
 - Находясь в директории kubernetes-vault применить в Vault политику otus-policy для секрета otus/cred
    **cat otus-policy.hcl | kubectl -n vault exec -it vault-0 -- vault policy write otus-policy -**
 - В Vault создать роль auth/kubernetes/role/otus:
      **kubectl -n vault exec -it vault-0 -- vault write auth/kubernetes/role/otus \\
        bound_service_account_names=vault-auth \\
        bound_service_account_namespaces=vault \\
        policies=otus-policy \\
        ttl=24h**
 - Добавить репозиторий external-secrets с helm-чартами external-secrets и установить chart:
    **helm repo add external-secrets https://charts.external-secrets.io
    helm upgrade --install external-secrets external-secrets/external-secrets --create-namespace -n vault**
 - В директории kubernetes-vault выполнить команду:
    **kubectl apply -f secretstore.yaml**
 - В директории kubernetes-vault выполнить команду:
    **kubectl apply -f externalsecret.yaml**

## Как проверить работоспособность:
 - Проверить, что запустились все поды в неймспейсе consul:
    **kubectl -n consul get po**
 - Проверить, что запустились все поды в неймспейсе vault:
    **kubectl -n vault get po**
 - Проверить, что в неймспейсе vault появился секрет otus-cred, хранящий ключи username и password со значениями, взятыми из секрета otus/cred в Vault
    **kubectl -n vault get secret otus-cred -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'**

## PR checklist:
 - [+] Выставлен label с темой домашнего задания
