### PR TITLE
homework 14

### DIFF
--- a/kubernetes-prod/README
+++ b/kubernetes-prod/README
@@ -1,0 +1,110 @@
+Выполнено ДЗ № 14
+[+] Основное ДЗ
+[+] Задание со *
+
+В процессе сделано:
+- Созданы 4 виртуальные машины в YC указанной конфигурации для разворачивания и обновления кластера Kubernetes с помощью kubeadm 
+- На всех машинах проведены подготовительные работы в соответствии с инструкцией
+- На всех ВМ установлены containerd, kubeadm, kubelet, kubectl. Последние 3 компонента версии 1.29.0-1.1
+- В качестве сетевого плагина был установлен Flannel
+- На мастер-ноде проинициализирован кластер Kubernetes версии 1.29 и присоединены 3 воркер ноды
+- Выполнено обновление мастер-ноды до последней актуальной версии Kubernets с помощью kubeadm
+- Последовательно были выведены из планирования все воркер-ноды, обновлены до последней актуальной версии и были возвращены в планирование
+- Созданы 5 виртуальных машин в YC указанной конфигурации для разворачивания кластера Kubernetes с помощью kubespray
+- Был развернут отказоустойчивый кластер Kubernetes с помощью kubespray
+
+Как запустить проект:
+- Переходим в директорию kubernetes-prod
+  cd kubernetes-prod
+- Копируем скрипт prepare_node.sh на все виртуальные машины в домашнюю директорию пользователя
+  scp prepare_node.sh <user>@<vm_ip>:~
+- Запускаем на каждой машине скрипт:
+  cd ~ && chmod +x prepare_node.sh && sudo ./prepare_node.sh
+Следующие действия производим на мастер-ноде
+- Запускаем команду инициализации кластера
+  kubeadm init --pod-network-cidr=10.244.0.0/16
+- Копируем конфиг для kubectl
+  mkdir -p $HOME/.kube
+  cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+  chown $(id -u):$(id -g) $HOME/.kube/config
+- Установливаем Flannel в качестве сетевого плагина
+  kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+- На воркер-нодах выполняем команду присоединения в кластер командой, которая была выдана в конце "kubeadm init"
+  sudo kubeadm join <IP_ADDRESS>:6443 --token <TOKEN> --discovery-token-ca-cert-hash sha256:<HASH>
+- Выполняем команду "kubectl get nodes -o wide"
+- Копируем скрипт upgrade_kubeadm.sh на все ноды кластера в домашнюю директорию пользователя
+  scp upgrade_kubeadm.sh <user>@<vm_ip>:~
+Следующие действия производим на мастер-ноде
+- Запускаем скрипт обновления kubeadm
+  cd ~ && chmod +x upgrade_kubeadm.sh && sudo ./upgrade_kubeadm.sh
+- Проверяем план обновления кластера
+  sudo kubeadm upgrade plan
+- Запускаем обновление кластера до версии 1.30.2
+  sudo kubeadm upgrade apply v1.30.2
+- Выводим из планирования ноду
+  kubectl drain <master-node-name> --ignore-daemonsets
+- Обновляем kubelet и kubectl
+  sudo apt-mark unhold kubelet kubectl && \
+  sudo apt-get update && sudo apt-get install -y kubelet='1.30.2-1.1' kubectl='1.30.2-1.1' && \
+  sudo apt-mark hold kubelet kubectl
+- Рестартуем kubelet
+  sudo systemctl daemon-reload
+  sudo systemctl restart kubelet
+- Возвращаем в планирование ноду
+  kubectl uncordon <master-node-name>
+- Обновляем локальную конфигурацию kubelet на воркер-нодах
+  sudo kubeadm upgrade node
+Следующие команды выполняем последовательно на каждой воркер-ноде. Опишем процесс для одной ноды
+- На воркер-ноде запускаем скрипт обновления kubeadm
+  cd ~ && chmod +x upgrade_kubeadm.sh && sudo ./upgrade_kubeadm.sh
+- На мастер-ноде запускаем команду вывода из планирования воркер-ноды
+  kubectl drain <worker-node-name> --ignore-daemonsets
+- Обновляем kubelet и kubectl на воркер-ноде
+  sudo apt-mark unhold kubelet kubectl && \
+  sudo apt-get update && sudo apt-get install -y kubelet='1.30.2-1.1' kubectl='1.30.2-1.1' && \
+  sudo apt-mark hold kubelet kubectl
+- Рестартуем kubelet на воркер-ноде
+  sudo systemctl daemon-reload
+  sudo systemctl restart kubelet
+- На мастер-ноде запускаем команду возвращения в планирование воркер-ноды
+  kubectl uncordon <worker-node-name>
+- После обновления всех воркер-нод запускам команду "kubectl get nodes -o wide"
+  
+Следующие шаги описывают процесс разворачивания отказоустойчивого кластера Kubernetes с помощью kubespray. Все шаги выполняем на первой мастер-ноде
+- Устанавливаем необходимые для работы ansible пакеты
+  sudo apt-get install -y python3
+  sudo apt-get install -y python3-pip
+  sudo apt-get install -y python3-venv
+- Устанавливаем ansible
+  VENVDIR=kubespray-venv
+  KUBESPRAYDIR=kubespray
+  python3 -m venv $VENVDIRye
+  source $VENVDIR/bin/activate
+  cd $KUBESPRAYDIR
+  pip install -U -r requirements.txt
+- Клонируем репозиторий kubespray
+  git clone https://github.com/kubernetes-sigs/kubespray.git
+- Переходим в склонированный репозиторий
+  cd kubespray
+- Копируем пример инвентаря в директорию для инвентарных файлов нашего кластера mycluster 
+  cp -rfp inventory/sample inventory/mycluster
+- Генерируем пару ключей
+  mkdir keys
+  ssh-keygen -t rsa -f "$(pwd)/keys/id_rsa" -P ""
+- Добавляем публичный ключ $(pwd)/keys/id_rsa.pub на все машины кластера (файл ~/.ssh/authorized_keys)
+- Обновляем данными по ip-адресам машин кластера инвентарный файл kubespray inventory/mycluster/inventory.ini. Инвентарный файл лежит по пути kubernetes-prod/inventory.ini
+- Запускаем плейбук по разворачиванию кластера
+  ansible-playbook -i inventory/mycluster/inventory.ini --become --become-user=root ansible_ssh_private_key_file=keys/id_rsa cluster.yml
+- Копируем конфиг для kubectl
+  mkdir -p $HOME/.kube
+  cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+  chown $(id -u):$(id -g) $HOME/.kube/config
+- Выполняем команду "kubectl get nodes -o wide"
+
+Как проверить работоспособность:
+- Проверить, что результат выполнения команды "kubectl get nodes -o wide" после разворачивания кластера версии 1.29.0 с помощью kubeadm коррелирует с содержимым файла kubernetes-prod/kubeadm.nodes.v1.29
+- Проверить, что результат выполнения команды "kubectl get nodes -o wide" после обновления кластера с помощью kubeadm до версии 1.30.2 коррелирует с содержимым файла kubernetes-prod/kubeadm.nodes.v1.30
+- Проверить, что результат выполнения команды "kubectl get nodes -o wide" после разворачивания кластера с помощью kubespray коррелирует с содержимым файла kubernetes-prod/kubespray.nodes
+
+PR checklist:
+[+] Выставлен label с темой домашнего задания

--- a/kubernetes-prod/inventory.ini
+++ b/kubernetes-prod/inventory.ini
@@ -1,0 +1,38 @@
+# ## Configure 'ip' variable to bind kubernetes services on a
+# ## different ip than the default iface
+# ## We should set etcd_member_name for etcd cluster. The node that is not a etcd member do not need to set the value, or can set the empty string value.
+[all]
+node1 ansible_host=10.128.0.13 ansible_ssh_private_key_file=~/kubespray/keys/id_rsa etcd_member_name=etcd1
+node2 ansible_host=10.128.0.8 ansible_ssh_private_key_file=~/kubespray/keys/id_rsa etcd_member_name=etcd2
+node3 ansible_host=10.128.0.18 ansible_ssh_private_key_file=~/kubespray/keys/id_rsa etcd_member_name=etcd3
+node4 ansible_host=10.128.0.23 ansible_ssh_private_key_file=~/kubespray/keys/id_rsa
+node5 ansible_host=10.128.0.21 ansible_ssh_private_key_file=~/kubespray/keys/id_rsa
+# node6 ansible_host=95.54.0.17  # ip=10.3.0.6 etcd_member_name=etcd6
+
+# ## configure a bastion host if your nodes are not directly reachable
+# [bastion]
+# bastion ansible_host=x.x.x.x ansible_user=some_user
+
+[kube_control_plane]
+node1
+node2
+node3
+
+[etcd]
+node1
+node2
+node3
+
+[kube_node]
+# node2
+# node3
+node4
+node5
+# node6
+
+[calico_rr]
+
+[k8s_cluster:children]
+kube_control_plane
+kube_node
+calico_rr

--- a/kubernetes-prod/kubeadm.nodes.v1.29
+++ b/kubernetes-prod/kubeadm.nodes.v1.29
@@ -1,0 +1,5 @@
+NAME       STATUS   ROLES           AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
+master     Ready    control-plane   70m     v1.29.0   10.128.0.30   <none>        Ubuntu 24.04 LTS     6.8.0-35-generic     containerd://1.7.18
+worker-1   Ready    <none>          61m     v1.29.0   10.128.0.23   <none>        Ubuntu 22.04.4 LTS   5.15.0-112-generic   containerd://1.7.18
+worker-2   Ready    <none>          8m28s   v1.29.0   10.128.0.16   <none>        Ubuntu 22.04.4 LTS   5.15.0-112-generic   containerd://1.7.18
+worker-3   Ready    <none>          18m     v1.29.0   10.128.0.31   <none>        Ubuntu 22.04.4 LTS   5.15.0-112-generic   containerd://1.7.18

--- a/kubernetes-prod/kubeadm.nodes.v1.30
+++ b/kubernetes-prod/kubeadm.nodes.v1.30
@@ -1,0 +1,5 @@
+NAME       STATUS   ROLES           AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
+master     Ready    control-plane   22h   v1.30.2   10.128.0.30   <none>        Ubuntu 24.04 LTS     6.8.0-35-generic     containerd://1.7.18
+worker-1   Ready    <none>          22h   v1.30.2   10.128.0.23   <none>        Ubuntu 22.04.4 LTS   5.15.0-112-generic   containerd://1.7.18
+worker-2   Ready    <none>          21h   v1.30.2   10.128.0.16   <none>        Ubuntu 22.04.4 LTS   5.15.0-112-generic   containerd://1.7.18
+worker-3   Ready    <none>          22h   v1.30.2   10.128.0.31   <none>        Ubuntu 22.04.4 LTS   5.15.0-112-generic   containerd://1.7.18

--- a/kubernetes-prod/kubespray.nodes
+++ b/kubernetes-prod/kubespray.nodes
@@ -1,0 +1,6 @@
+NAME    STATUS   ROLES           AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
+node1   Ready    control-plane   87m   v1.29.5   10.128.0.13   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node2   Ready    control-plane   86m   v1.29.5   10.128.0.8    <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node3   Ready    control-plane   86m   v1.29.5   10.128.0.18   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node4   Ready    <none>          85m   v1.29.5   10.128.0.23   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16
+node5   Ready    <none>          85m   v1.29.5   10.128.0.21   <none>        Ubuntu 24.04 LTS   6.8.0-35-generic   containerd://1.7.16

--- a/kubernetes-prod/prepare_node.sh
+++ b/kubernetes-prod/prepare_node.sh
@@ -1,0 +1,72 @@
+CONTAINERD_VERSION=1.7.18
+RUNC_VERSION=v1.1.12
+CNI_PLUGINS_VERSION=v1.5.0
+OS=linux
+ARCH=amd64
+K8S_VERSION_MINOR=1.29
+
+cat <<EOF | sudo tee /etc/modules-load.d/k8s.conf
+overlay
+br_netfilter
+EOF
+
+# Enable IPv4 packet forwarding
+sudo modprobe overlay
+sudo modprobe br_netfilter
+
+# sysctl params required by setup, params persist across reboots
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf
+net.bridge.bridge-nf-call-iptables  = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward                 = 1
+EOF
+
+# Apply sysctl params without reboot
+sudo sysctl --system
+
+# Disable swap
+sudo swapoff -a
+(crontab -l 2>/dev/null; echo "@reboot /sbin/swapoff -a") | crontab - || true
+
+# Install containerd
+curl -s -L -O https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION-$OS-$ARCH.tar.gz
+curl -s -L -O https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-$CONTAINERD_VERSION-$OS-$ARCH.tar.gz.sha256sum
+echo "$(cat containerd-$CONTAINERD_VERSION-$OS-$ARCH.tar.gz.sha256sum)" | sha256sum --check
+tar Cxzvf /usr/local containerd-$CONTAINERD_VERSION-$OS-$ARCH.tar.gz
+curl -s -L -o /lib/systemd/system/containerd.service https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
+systemctl daemon-reload
+systemctl enable --now containerd
+
+# Configuring the systemd cgroup driver
+mkdir /etc/containerd
+touch /etc/containerd/config.toml
+containerd config default > /etc/containerd/config.toml
+sed -i "s/SystemdCgroup = false/SystemdCgroup = true/" /etc/containerd/config.toml
+systemctl restart containerd
+
+# Install runc
+curl -s -L -O https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.$ARCH
+curl -s -L -O https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.sha256sum
+echo "$(cat runc.sha256sum | grep $ARCH)" | sha256sum --check
+install -m 755 runc.amd64 /usr/local/sbin/runc
+
+# Install CNI plugins
+curl -s -L -O https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGINS_VERSION/cni-plugins-$OS-$ARCH-$CNI_PLUGINS_VERSION.tgz
+curl -s -L -O https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGINS_VERSION/cni-plugins-$OS-$ARCH-$CNI_PLUGINS_VERSION.tgz.sha256
+echo "$(cat cni-plugins-$OS-$ARCH-$CNI_PLUGINS_VERSION.tgz.sha256)" | sha256sum --check
+mkdir -p /opt/cni/bin
+tar Cxzvf /opt/cni/bin cni-plugins-linux-amd64-v1.1.1.tgz
+
+# Install kubeadm, kubelet and kubectl
+sudo apt-get update
+# apt-transport-https may be a dummy package; if so, you can skip that package
+sudo apt-get install -y apt-transport-https ca-certificates curl gpg
+# If the directory `/etc/apt/keyrings` does not exist, it should be created before the curl command, read the note below.
+# sudo mkdir -p -m 755 /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION_MINOR}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+# This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION_MINOR}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt-get update
+sudo apt-get install -y kubelet=1.29.0-1.1 kubeadm=1.29.0-1.1 kubectl=1.29.0-1.1
+sudo apt-mark hold kubelet kubeadm kubectl
+sudo systemctl enable --now kubelet

--- a/kubernetes-prod/upgrade_kubeadm.sh
+++ b/kubernetes-prod/upgrade_kubeadm.sh
@@ -1,0 +1,29 @@
+K8S_VERSION_MINOR=1.30
+
+# If the directory `/etc/apt/keyrings` does not exist, it should be created before the curl command, read the note below.
+# sudo mkdir -p -m 755 /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION_MINOR}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+# This overwrites any existing configuration in /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v${K8S_VERSION_MINOR}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+# Upgrade kubeadm
+sudo apt-mark unhold kubeadm && \
+sudo apt-get update && sudo apt-get install -y kubeadm='1.30.2-1.1' && \
+sudo apt-mark hold kubeadm
+
+# sudo kubeadm upgrade node
+
+# # Drain the node 
+# kubectl drain $node_name --ignore-daemonsets
+
+# # Upgrade the kubelet and kubectl
+# sudo apt-mark unhold kubelet kubectl && \
+# sudo apt-get update && sudo apt-get install -y kubelet='1.30.2-1.1' kubectl='1.30.2-1.1' && \
+# sudo apt-mark hold kubelet kubectl
+
+# # Restart the kubelet
+# sudo systemctl daemon-reload
+# sudo systemctl restart kubelet
+
+# # Uncordon the node
+# kubectl uncordon $node_name


### PR DESCRIPTION
# Выполнено ДЗ № 14

 - [+] Основное ДЗ
 - [+] Задание со *

## В процессе сделано:
 - Созданы 4 виртуальные машины в YC указанной конфигурации для разворачивания и обновления кластера Kubernetes с помощью kubeadm 
 - На всех машинах проведены подготовительные работы в соответствии с инструкцией
 - На всех ВМ установлены containerd, kubeadm, kubelet, kubectl. Последние 3 компонента версии 1.29.0-1.1
 - В качестве сетевого плагина был установлен Flannel
 - На мастер-ноде проинициализирован кластер Kubernetes версии 1.29 и присоединены 3 воркер ноды
 - Выполнено обновление мастер-ноды до последней актуальной версии Kubernets с помощью kubeadm
 - Последовательно были выведены из планирования все воркер-ноды, обновлены до последней актуальной версии и были возвращены в планирование
 - Созданы 5 виртуальных машин в YC указанной конфигурации для разворачивания кластера Kubernetes с помощью kubespray
 - Был развернут отказоустойчивый кластер Kubernetes с помощью kubespray

## Как запустить проект:
 - Переходим в директорию kubernetes-prod
    cd kubernetes-prod
 - Копируем скрипт prepare_node.sh на все виртуальные машины в домашнюю директорию пользователя
    scp prepare_node.sh <user>@<vm_ip>:~
 - Запускаем на каждой машине скрипт:
    cd ~ && chmod +x prepare_node.sh && sudo ./prepare_node.sh
 Следующие действия производим на мастер-ноде
 - Запускаем команду инициализации кластера
    kubeadm init --pod-network-cidr=10.244.0.0/16
 - Копируем конфиг для kubectl
    mkdir -p $HOME/.kube
    cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
    chown $(id -u):$(id -g) $HOME/.kube/config
 - Установливаем Flannel в качестве сетевого плагина
    kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
 - На воркер-нодах выполняем команду присоединения в кластер командой, которая была выдана в конце "kubeadm init"
    sudo kubeadm join <IP_ADDRESS>:6443 --token <TOKEN> --discovery-token-ca-cert-hash sha256:<HASH>
 - Выполняем команду "kubectl get nodes -o wide"
 - Копируем скрипт upgrade_kubeadm.sh на все ноды кластера в домашнюю директорию пользователя
    scp upgrade_kubeadm.sh <user>@<vm_ip>:~
 Следующие действия производим на мастер-ноде
 - Запускаем скрипт обновления kubeadm
    cd ~ && chmod +x upgrade_kubeadm.sh && sudo ./upgrade_kubeadm.sh
 - Проверяем план обновления кластера
    sudo kubeadm upgrade plan
 - Запускаем обновление кластера до версии 1.30.2
   sudo kubeadm upgrade apply v1.30.2
 - Выводим из планирования ноду
    kubectl drain <master-node-name> --ignore-daemonsets
 - Обновляем kubelet и kubectl
    sudo apt-mark unhold kubelet kubectl && \
    sudo apt-get update && sudo apt-get install -y kubelet='1.30.2-1.1' kubectl='1.30.2-1.1' && \
    sudo apt-mark hold kubelet kubectl
 - Рестартуем kubelet
    sudo systemctl daemon-reload
    sudo systemctl restart kubelet
 - Возвращаем в планирование ноду
    kubectl uncordon <master-node-name>
 - Обновляем локальную конфигурацию kubelet на воркер-нодах
    sudo kubeadm upgrade node
 Следующие команды выполняем последовательно на каждой воркер-ноде. Опишем процесс для одной ноды
 - На воркер-ноде запускаем скрипт обновления kubeadm
    cd ~ && chmod +x upgrade_kubeadm.sh && sudo ./upgrade_kubeadm.sh
 - На мастер-ноде запускаем команду вывода из планирования воркер-ноды
    kubectl drain <worker-node-name> --ignore-daemonsets
 - Обновляем kubelet и kubectl на воркер-ноде
    sudo apt-mark unhold kubelet kubectl && \
    sudo apt-get update && sudo apt-get install -y kubelet='1.30.2-1.1' kubectl='1.30.2-1.1' && \
    sudo apt-mark hold kubelet kubectl
 - Рестартуем kubelet на воркер-ноде
    sudo systemctl daemon-reload
    sudo systemctl restart kubelet
 - На мастер-ноде запускаем команду возвращения в планирование воркер-ноды
    kubectl uncordon <worker-node-name>
 - После обновления всех воркер-нод запускам команду "kubectl get nodes -o wide" 
 Следующие шаги описывают процесс разворачивания отказоустойчивого кластера Kubernetes с помощью kubespray. Все шаги выполняем на первой мастер-ноде
 - Устанавливаем необходимые для работы ansible пакеты
    sudo apt-get install -y python3
    sudo apt-get install -y python3-pip
    sudo apt-get install -y python3-venv
 - Устанавливаем ansible
    VENVDIR=kubespray-venv
    KUBESPRAYDIR=kubespray
    python3 -m venv $VENVDIRye
    source $VENVDIR/bin/activate
    cd $KUBESPRAYDIR
    pip install -U -r requirements.txt
 - Клонируем репозиторий kubespray
    git clone https://github.com/kubernetes-sigs/kubespray.git
 - Переходим в склонированный репозиторий
    cd kubespray
 - Копируем пример инвентаря в директорию для инвентарных файлов нашего кластера mycluster 
    cp -rfp inventory/sample inventory/mycluster
 - Генерируем пару ключей
    mkdir keys
    ssh-keygen -t rsa -f "$(pwd)/keys/id_rsa" -P ""
 - Добавляем публичный ключ $(pwd)/keys/id_rsa.pub на все машины кластера (файл ~/.ssh/authorized_keys)
 - Обновляем данными по ip-адресам машин кластера инвентарный файл kubespray inventory/mycluster/inventory.ini. Инвентарный файл лежит по пути kubernetes-prod/inventory.ini
 - Запускаем плейбук по разворачиванию кластера
    ansible-playbook -i inventory/mycluster/inventory.ini --become --become-user=root cluster.yml
 - Копируем конфиг для kubectl
    mkdir -p $HOME/.kube
    cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
    chown $(id -u):$(id -g) $HOME/.kube/config
 - Выполняем команду "kubectl get nodes -o wide"

## Как проверить работоспособность:
 - Проверить, что результат выполнения команды "kubectl get nodes -o wide" после разворачивания кластера версии 1.29.0 с помощью kubeadm коррелирует с содержимым файла kubernetes-prod/kubeadm.nodes.v1.29
 - Проверить, что результат выполнения команды "kubectl get nodes -o wide" после обновления кластера с помощью kubeadm до версии 1.30.2 коррелирует с содержимым файла kubernetes-prod/kubeadm.nodes.v1.30
 - Проверить, что результат выполнения команды "kubectl get nodes -o wide" после разворачивания кластера с помощью kubespray коррелирует с содержимым файла kubernetes-prod/kubespray.nodes

## PR checklist:
 - [+] Выставлен label с темой домашнего задания
